### PR TITLE
Replace delayMicroseconds by _delay_us

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -142,7 +142,7 @@ sample code bearing this copyright.
 #include <Arduino.h>
 #include "OneWire.h"
 #include "util/OneWire_direct_gpio.h"
-
+#include "avr/delay.h"
 
 void OneWire::begin(uint8_t pin)
 {
@@ -174,20 +174,20 @@ uint8_t OneWire::reset(void)
 	// wait until the wire is high... just in case
 	do {
 		if (--retries == 0) return 0;
-		delayMicroseconds(2);
+		_delay_us(2);
 	} while ( !DIRECT_READ(reg, mask));
 
 	noInterrupts();
 	DIRECT_WRITE_LOW(reg, mask);
 	DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
 	interrupts();
-	delayMicroseconds(480);
+	_delay_us(480);
 	noInterrupts();
 	DIRECT_MODE_INPUT(reg, mask);	// allow it to float
-	delayMicroseconds(70);
+	_delay_us(70);
 	r = !DIRECT_READ(reg, mask);
 	interrupts();
-	delayMicroseconds(410);
+	_delay_us(410);
 	return r;
 }
 
@@ -204,18 +204,18 @@ void OneWire::write_bit(uint8_t v)
 		noInterrupts();
 		DIRECT_WRITE_LOW(reg, mask);
 		DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
-		delayMicroseconds(10);
+		_delay_us(10);
 		DIRECT_WRITE_HIGH(reg, mask);	// drive output high
 		interrupts();
-		delayMicroseconds(55);
+		_delay_us(55);
 	} else {
 		noInterrupts();
 		DIRECT_WRITE_LOW(reg, mask);
 		DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
-		delayMicroseconds(65);
+		_delay_us(65);
 		DIRECT_WRITE_HIGH(reg, mask);	// drive output high
 		interrupts();
-		delayMicroseconds(5);
+		_delay_us(5);
 	}
 }
 
@@ -232,12 +232,12 @@ uint8_t OneWire::read_bit(void)
 	noInterrupts();
 	DIRECT_MODE_OUTPUT(reg, mask);
 	DIRECT_WRITE_LOW(reg, mask);
-	delayMicroseconds(3);
+	_delay_us(3);
 	DIRECT_MODE_INPUT(reg, mask);	// let pin float, pull up will raise
-	delayMicroseconds(10);
+	_delay_us(10);
 	r = DIRECT_READ(reg, mask);
 	interrupts();
-	delayMicroseconds(53);
+	_delay_us(53);
 	return r;
 }
 


### PR DESCRIPTION
Hi, little fix for my project, maybe there are better ways to fix it.
I was working with ATtiny1614 (at 1MHz) when my DS18B20 was not responding with this library. I tried 4 and 8 MHz with success but 1MHz is too low for current implementation.
After investigating, the overhead of delayMicroseconds seems to be the cause. I replaced it with _delay_us from AVR libraries and it works like a charm.